### PR TITLE
Use prop-types to remove deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/yanbingbing/rc-qrcode/issues"
   },
-  "homepage": "https://github.com/yanbingbing/rc-qrcode#readme"
+  "homepage": "https://github.com/yanbingbing/rc-qrcode#readme",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const PropTypes = require('prop-types');
 const React = require('react');
 const {QRCode, QRErrorCorrectLevel, QRCapacityTable, UTF8Array} = require('./qrcode');
 
@@ -149,18 +150,18 @@ ReactQRCode.defaultProps = {
 };
 
 ReactQRCode.propTypes = {
-    renderer: React.PropTypes.oneOf(['canvas', 'svg', 'auto']),
-    content: React.PropTypes.string,
-    scale: React.PropTypes.oneOfType([
-        React.PropTypes.number,
-        React.PropTypes.string
+    renderer: PropTypes.oneOf(['canvas', 'svg', 'auto']),
+    content: PropTypes.string,
+    scale: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string
     ]),
-    margin: React.PropTypes.oneOfType([
-        React.PropTypes.number,
-        React.PropTypes.string
+    margin: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.string
     ]),
-    background: React.PropTypes.string,
-    foreground: React.PropTypes.string
+    background: PropTypes.string,
+    foreground: PropTypes.string
 };
 
 module.exports = ReactQRCode;


### PR DESCRIPTION
To fix a "lowPriorityWarning" that appears in `console.warn` when rc-qrcode is used in React v15:

> lowPriorityWarning.js:40 Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs